### PR TITLE
Changed next and prev posts to use published date instead of id

### DIFF
--- a/components/NextPrev.php
+++ b/components/NextPrev.php
@@ -76,18 +76,19 @@ class NextPrev extends ComponentBase
     public function getNP($pp){
         $params = ($pp=='Next') ? array(0 =>'>',1 => 'asc') : array(0 => '<', 1 => 'desc');
         $currentPostId =  $this->getPostId();
+        $currentPost = Post::where( 'id', $currentPostId)->first();
         $category = $this->getCategory();
 
        if($currentPostId != 0){
             $post =  Post::isPublished();
-                $post   ->where('id',$params[0],$currentPostId)
-                        ->orderBy('id',$params[1]);
-                if ($category !== null) {
-                    if (!is_array($category)) $category = [$category];
-                    $post->whereHas('categories', function($q) use ($category) {
-                        $q->whereIn('id', $category);
-                    });
-                }
+            $post   ->where('published_at',$params[0],$currentPost->published_at)
+                    ->orderBy('published_at',$params[1]);
+            if ($category !== null) {
+                if (!is_array($category)) $category = [$category];
+                $post->whereHas('categories', function($q) use ($category) {
+                    $q->whereIn('id', $category);
+                });
+            }
             $np = $post->first();
 
             /* Agregamos el helper de la URL */


### PR DESCRIPTION
I've changed the getNP() Method to use the published_at date instead of id to determine which post comes next and previous.
This makes more sense since not always posts are published in the order of creation.